### PR TITLE
Adding request header overrides

### DIFF
--- a/packages/@uppy/companion/src/server/Uploader.js
+++ b/packages/@uppy/companion/src/server/Uploader.js
@@ -158,6 +158,7 @@ class Uploader {
    * @property {string} [httpMethod]
    * @property {boolean} [useFormData]
    * @property {number} [chunkSize]
+   * @property {any} [clientRequest]
    *
    * @param {UploaderOptions} options
    */
@@ -175,6 +176,8 @@ class Uploader {
       : this.fileName
 
     this.storage = options.storage
+
+    this.clientRequest = options.clientRequest
 
     this.downloadedBytes = 0
 
@@ -365,6 +368,7 @@ class Uploader {
       uploadUrl: req.body.uploadUrl,
       metadata: req.body.metadata,
       fieldname: req.body.fieldname,
+      clientRequest: req,
       useFormData,
 
       // Info coming from companion server configuration:
@@ -377,6 +381,7 @@ class Uploader {
         options: req.companion.options.s3,
       } : null,
       chunkSize: req.companion.options.chunkSize,
+      uploaderOptions: req.companion.options.uploaderOptions,
     }
   }
 
@@ -574,8 +579,24 @@ class Uploader {
     return tusRet;
   }
 
+  static buildRequestHeaders(clientRequest, additionalHeaders, uploaderOptions) {
+    const finalHeaders = headerSanitize(additionalHeaders || {});
+
+    if (uploaderOptions.proxyAuth === "true") {
+      const authCookie = clientRequest.cookies[uploaderOptions.proxyAuthCookieName]
+      if (authCookie) {
+        finalHeaders[uploaderOptions.proxyAuthHeaderName] = `Bearer ${authCookie}`
+      }
+    }
+
+    return finalHeaders
+  }
+
   async #uploadMultipart(stream) {
-    if (!this.options.endpoint) {
+    const uploaderOptions = this.options.uploaderOptions || {}
+    const {endpoint} = uploaderOptions
+
+    if (!endpoint) {
       throw new Error('No multipart endpoint set')
     }
 
@@ -598,9 +619,8 @@ class Uploader {
       this.onProgress(bytesUploaded, undefined)
     })
 
-    const url = this.options.endpoint
     const reqOptions = {
-      headers: headerSanitize(this.options.headers),
+      headers: Uploader.buildRequestHeaders(this.options.clientRequest, this.options.headers, uploaderOptions),
     }
 
     if (this.options.useFormData) {
@@ -624,7 +644,7 @@ class Uploader {
       const httpMethod = (this.options.httpMethod || '').toUpperCase() === 'PUT' ? 'put' : 'post'
       const runRequest = (await got)[httpMethod]
 
-      const response = await runRequest(url, reqOptions)
+      const response = await runRequest(endpoint, reqOptions)
 
       if (this.size != null && bytesUploaded !== this.size) {
         const errMsg = `uploaded only ${bytesUploaded} of ${this.size} with status: ${response.statusCode}`

--- a/packages/@uppy/companion/src/server/Uploader.js
+++ b/packages/@uppy/companion/src/server/Uploader.js
@@ -159,6 +159,7 @@ class Uploader {
    * @property {boolean} [useFormData]
    * @property {number} [chunkSize]
    * @property {any} [clientRequest]
+   * @property {any} endpointOptions
    *
    * @param {UploaderOptions} options
    */
@@ -381,7 +382,7 @@ class Uploader {
         options: req.companion.options.s3,
       } : null,
       chunkSize: req.companion.options.chunkSize,
-      uploaderOptions: req.companion.options.uploaderOptions,
+      endpointOptions: req.companion.options.endpointOptions,
     }
   }
 
@@ -579,13 +580,13 @@ class Uploader {
     return tusRet;
   }
 
-  static buildRequestHeaders(clientRequest, additionalHeaders, uploaderOptions) {
+  static buildRequestHeaders(clientRequest, additionalHeaders, endpointOptions) {
     const finalHeaders = headerSanitize(additionalHeaders || {});
 
-    if (uploaderOptions.proxyAuth === "true") {
-      const authCookie = clientRequest.cookies[uploaderOptions.proxyAuthCookieName]
+    if (endpointOptions.proxyAuth === "true") {
+      const authCookie = clientRequest.cookies[endpointOptions.proxyAuthCookieName]
       if (authCookie) {
-        finalHeaders[uploaderOptions.proxyAuthHeaderName] = `Bearer ${authCookie}`
+        finalHeaders[endpointOptions.proxyAuthHeaderName] = `Bearer ${authCookie}`
       }
     }
 
@@ -593,8 +594,8 @@ class Uploader {
   }
 
   async #uploadMultipart(stream) {
-    const uploaderOptions = this.options.uploaderOptions || {}
-    const {endpoint} = uploaderOptions
+    const endpointOptions = this.options.endpointOptions || {}
+    const {endpoint} = endpointOptions
 
     if (!endpoint) {
       throw new Error('No multipart endpoint set')
@@ -620,7 +621,7 @@ class Uploader {
     })
 
     const reqOptions = {
-      headers: Uploader.buildRequestHeaders(this.options.clientRequest, this.options.headers, uploaderOptions),
+      headers: Uploader.buildRequestHeaders(this.options.clientRequest, this.options.headers, endpointOptions),
     }
 
     if (this.options.useFormData) {

--- a/packages/@uppy/companion/src/standalone/helper.js
+++ b/packages/@uppy/companion/src/standalone/helper.js
@@ -193,7 +193,7 @@ const getConfigFromEnv = () => {
     corsOrigins: getCorsOrigins(),
     testDynamicOauthCredentials: process.env.COMPANION_TEST_DYNAMIC_OAUTH_CREDENTIALS === 'true',
     testDynamicOauthCredentialsSecret: process.env.COMPANION_TEST_DYNAMIC_OAUTH_CREDENTIALS_SECRET,
-    uploaderOptions: {
+    endpointOptions: {
       endpoint: process.env.COMPANION_UPLOADER_ENDPOINT,
       proxyAuth: process.env.COMPANION_UPLOADER_PROXY_AUTH,
       proxyAuthCookieName: process.env.COMPANION_UPLOADER_PROXY_AUTH_COOKIE_NAME || "__s__",

--- a/packages/@uppy/companion/src/standalone/helper.js
+++ b/packages/@uppy/companion/src/standalone/helper.js
@@ -193,6 +193,12 @@ const getConfigFromEnv = () => {
     corsOrigins: getCorsOrigins(),
     testDynamicOauthCredentials: process.env.COMPANION_TEST_DYNAMIC_OAUTH_CREDENTIALS === 'true',
     testDynamicOauthCredentialsSecret: process.env.COMPANION_TEST_DYNAMIC_OAUTH_CREDENTIALS_SECRET,
+    uploaderOptions: {
+      endpoint: process.env.COMPANION_UPLOADER_ENDPOINT,
+      proxyAuth: process.env.COMPANION_UPLOADER_PROXY_AUTH,
+      proxyAuthCookieName: process.env.COMPANION_UPLOADER_PROXY_AUTH_COOKIE_NAME || "__s__",
+      proxyAuthHeaderName: process.env.COMPANION_UPLOADER_PROXY_AUTH_HEADER_NAME || "Authorization",
+    }
   }
 }
 


### PR DESCRIPTION
* Updates companion to restrict backend endpoint to pre-configured url
* Updates companion to allow for access token pass-through via `Authorization` header