### PR TITLE
fix: TypeScript build error in logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "turbo": "^2.5.4",
     "typescript": "^5.8.3"
   },
-  "packageManager": "yarn@4.4.1+sha224.fd21d9eb5fba020083811af1d4953acc21eeb9f6ff97efd1b3f9d4de",
+  "packageManager": "yarn@4.12.0+sha512.f45ab632439a67f8bc759bf32ead036a1f413287b9042726b7cc4818b7b49e14e9423ba49b18f9e06ea4941c1ad062385b1d8760a8d5091a1a31e5f6219afca8",
   "engines": {
     "node": ">=20.19.0"
   }

--- a/packages/@uppy/companion/src/server/Uploader.js
+++ b/packages/@uppy/companion/src/server/Uploader.js
@@ -147,7 +147,7 @@ export default class Uploader {
    * @property {boolean} [useFormData]
    * @property {number} [chunkSize]
    * @property {any} [clientRequest]
-   * @property {any} endpointOptions
+   * @property {any} [endpointOptions]
    * @property {string} [providerName]
    *
    * @param {UploaderOptions} optionsIn
@@ -638,13 +638,19 @@ export default class Uploader {
     return tusRet
   }
 
-  static buildRequestHeaders(clientRequest, additionalHeaders, endpointOptions) {
-    const finalHeaders = headerSanitize(additionalHeaders || {});
+  static buildRequestHeaders(
+    clientRequest,
+    additionalHeaders,
+    endpointOptions,
+  ) {
+    const finalHeaders = headerSanitize(additionalHeaders || {})
 
-    if (endpointOptions.proxyAuth === "true") {
-      const authCookie = clientRequest.cookies[endpointOptions.proxyAuthCookieName]
+    if (endpointOptions.proxyAuth === 'true') {
+      const authCookie =
+        clientRequest.cookies[endpointOptions.proxyAuthCookieName]
       if (authCookie) {
-        finalHeaders[endpointOptions.proxyAuthHeaderName] = `Bearer ${authCookie}`
+        finalHeaders[endpointOptions.proxyAuthHeaderName] =
+          `Bearer ${authCookie}`
       }
     }
 
@@ -653,7 +659,7 @@ export default class Uploader {
 
   async #uploadMultipart(stream) {
     const endpointOptions = this.options.endpointOptions || {}
-    const {endpoint} = endpointOptions
+    const { endpoint } = endpointOptions
 
     if (!endpoint) {
       throw new Error('No multipart endpoint set')
@@ -683,7 +689,11 @@ export default class Uploader {
     })
 
     const reqOptions = {
-      headers: Uploader.buildRequestHeaders(this.options.clientRequest, this.options.headers, endpointOptions),
+      headers: Uploader.buildRequestHeaders(
+        this.options.clientRequest,
+        this.options.headers,
+        endpointOptions,
+      ),
     }
 
     if (this.options.useFormData) {

--- a/packages/@uppy/companion/src/server/logger.js
+++ b/packages/@uppy/companion/src/server/logger.js
@@ -46,7 +46,7 @@ const styleText =
  * @typedef {Parameters<styleText>[0]} Colors
  *
  * @param {object} params
- * @param {string | Error} params.arg the message or error to log
+ * @param {string | Error | object} params.arg the message or error to log
  * @param {string} params.tag a unique tag to easily search for this message
  * @param {string} params.level error | info | debug
  * @param {string} [params.traceId] a unique id to easily trace logs tied to a request
@@ -107,7 +107,7 @@ export function warn(msg, tag, traceId) {
 /**
  * ERROR level log
  *
- * @param {string | Error} msg the message to log
+ * @param {string | Error | object} msg the message to log
  * @param {string} [tag] a unique tag to easily search for this message
  * @param {string} [traceId] a unique id to easily trace logs tied to a request
  */

--- a/packages/@uppy/companion/src/server/provider/providerErrors.js
+++ b/packages/@uppy/companion/src/server/provider/providerErrors.js
@@ -63,10 +63,18 @@ export async function withProviderErrorHandling({
         knownErr = new ProviderAuthError()
       } else if (isNotFoundError({ statusCode, body })) {
         const message = getErrorMessage({ statusCode, body })
-        knownErr = new ProviderNotFoundError(message, statusCode, requestContext)
+        knownErr = new ProviderNotFoundError(
+          message,
+          statusCode,
+          requestContext,
+        )
       } else if (isPermissionError({ statusCode, body })) {
         const message = getErrorMessage({ statusCode, body })
-        knownErr = new ProviderPermissionError(message, statusCode, requestContext)
+        knownErr = new ProviderPermissionError(
+          message,
+          statusCode,
+          requestContext,
+        )
       } else if (isUserFacingError({ statusCode, body })) {
         knownErr = new ProviderUserError({
           message: getErrorMessage({ statusCode, body }),

--- a/packages/@uppy/companion/test/uploader.test.js
+++ b/packages/@uppy/companion/test/uploader.test.js
@@ -216,6 +216,7 @@ describe('uploader', () => {
     const opts = {
       companionOptions: { ...companionOptions, ...extraCompanionOpts },
       endpoint: `http://${address}`,
+      endpointOptions: { endpoint: `http://${address}` },
       protocol: 'multipart',
       size: includeSize ? fileContent.length : undefined,
       metadata,

--- a/yarn.lock
+++ b/yarn.lock
@@ -25547,31 +25547,31 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A^5#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.1.6#optional!builtin<compat/typescript>":
   version: 5.9.2
-  resolution: "typescript@patch:typescript@npm%3A5.9.2#optional!builtin<compat/typescript>::version=5.9.2&hash=8c6c40"
+  resolution: "typescript@patch:typescript@npm%3A5.9.2#optional!builtin<compat/typescript>::version=5.9.2&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/a8606016982f2f46ed085e9b4b84d8a5251b42ff0560c995c20f3c3ab9543e37c1015d92ab2f1cc7b2af2b499d12bac57e11789da271fb3225af8ec0b24e5b64
+  checksum: 10/bd810ab13e8e557225a8b5122370385440b933e4e077d5c7641a8afd207fdc8be9c346e3c678adba934b64e0e70b0acf5eef9493ea05170a48ce22bef845fdc7
   languageName: node
   linkType: hard
 
 "typescript@patch:typescript@npm%3A^5.0.0#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.8.3#optional!builtin<compat/typescript>":
   version: 5.8.3
-  resolution: "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=8c6c40"
+  resolution: "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/98470634034ec37fd9ea61cc82dcf9a27950d0117a4646146b767d085a2ec14b137aae9642a83d1c62732d7fdcdac19bb6288b0bb468a72f7a06ae4e1d2c72c9
+  checksum: 10/b9b1e73dabac5dc730c041325dbd9c99467c1b0d239f1b74ec3b90d831384af3e2ba973946232df670519147eb51a2c20f6f96163cea2b359f03de1e2091cc4f
   languageName: node
   linkType: hard
 
 "typescript@patch:typescript@npm%3A^5.7.3#optional!builtin<compat/typescript>":
   version: 5.8.2
-  resolution: "typescript@patch:typescript@npm%3A5.8.2#optional!builtin<compat/typescript>::version=5.8.2&hash=8c6c40"
+  resolution: "typescript@patch:typescript@npm%3A5.8.2#optional!builtin<compat/typescript>::version=5.8.2&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/6ae9b2c4d3254ec2eaee6f26ed997e19c02177a212422993209f81e87092b2bb0a4738085549c5b0164982a5609364c047c72aeb281f6c8d802cd0d1c6f0d353
+  checksum: 10/97920a082ffc57583b1cb6bc4faa502acc156358e03f54c7fc7fdf0b61c439a717f4c9070c449ee9ee683d4cfc3bb203127c2b9794b2950f66d9d307a4ff262c
   languageName: node
   linkType: hard
 
@@ -25587,11 +25587,11 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A~5.7.2#optional!builtin<compat/typescript>":
   version: 5.7.3
-  resolution: "typescript@patch:typescript@npm%3A5.7.3#optional!builtin<compat/typescript>::version=5.7.3&hash=8c6c40"
+  resolution: "typescript@patch:typescript@npm%3A5.7.3#optional!builtin<compat/typescript>::version=5.7.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/3ac7b7e3e899273d2fbdce6e24b93d4d53a705ad7a7e4cc83b4c57bcb6d25948abcd2a21994f6b9c73ab03960f395aae95f0458de292a66ce0134233261714c3
+  checksum: 10/dc58d777eb4c01973f7fbf1fd808aad49a0efdf545528dab9b07d94fdcb65b8751742804c3057e9619a4627f2d9cc85547fdd49d9f4326992ad0181b49e61d81
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
Fixes build, typecheck, test, and CI errors from the enhanced error handling PR.

## Changes

### Type Fixes
1. **logger.js** - Updated JSDoc types to allow `object` for structured logging:
   - Line 49: `@param {string | Error | object} params.arg`
   - Line 110: `@param {string | Error | object} msg`

2. **Uploader.js** - Made `endpointOptions` optional in UploaderOptions typedef (line 150)

### Formatting Fixes
3. **Uploader.js** - Applied Biome formatting fixes
4. **providerErrors.js** - Applied Biome formatting fixes

### Test Fixes
5. **uploader.test.js** - Fixed multipart test to pass both `endpoint` (for validation) and `endpointOptions.endpoint` (for actual upload)

### CI Fixes
6. **package.json** - Updated Yarn from 4.4.1 to 4.12.0 (old version no longer available on registry)

## Local Testing
- `yarn install` ✅
- `yarn build` ✅
- `yarn typecheck` ✅  
- `yarn check:ci` ✅
- `yarn workspace @uppy/companion test` ✅ (115 tests pass)

🤖 Generated with [Claude Code](https://claude.ai/code)